### PR TITLE
Handle init & external changes for onChange callbacks

### DIFF
--- a/src/directives/changed.js
+++ b/src/directives/changed.js
@@ -5,7 +5,7 @@
  * Takes the form definition as argument.
  * If the form definition has a "onChange" defined as either a function or
  */
-angular.module('schemaForm').directive('sfChanged', function() {
+angular.module('schemaForm').directive('sfChanged', ['sfPath', function(sfPath) {
   return {
     require: 'ngModel',
     restrict: 'AC',
@@ -15,14 +15,14 @@ angular.module('schemaForm').directive('sfChanged', function() {
       //"form" is really guaranteed to be here since the decorator directive
       //waits for it. But best be sure.
       if (form && form.onChange) {
-        ctrl.$viewChangeListeners.push(function() {
+        scope.$watch('model'+sfPath.normalize(form.key), function(newValue) {
           if (angular.isFunction(form.onChange)) {
-            form.onChange(ctrl.$modelValue, form);
+            form.onChange(newValue, form);
           } else {
-            scope.evalExpr(form.onChange, {'modelValue': ctrl.$modelValue, form: form});
+            scope.evalExpr(form.onChange, {'modelValue': newValue, form: form});
           }
-        });
+        })
       }
     }
   };
-});
+}]);

--- a/test/directives/schema-form-test.js
+++ b/test/directives/schema-form-test.js
@@ -1620,4 +1620,36 @@ describe('directive',function(){
     });
   });
 
+  it('should call onChange callback with initial value and with external update',function(){
+
+    inject(function($compile,$rootScope){
+      var scope = $rootScope.$new();
+      
+      scope.person = {
+        name:'Foo'
+      };
+
+      scope.schema = exampleSchema;
+
+      scope.form = [{ 
+        key:'name',
+        onChange: sinon.spy()
+      }];
+
+      var tmpl = angular.element('<form sf-schema="schema" sf-form="form" sf-model="person"></form>');
+
+      $compile(tmpl)(scope);
+      $rootScope.$apply();
+
+      scope.form[0].onChange.should.have.been.calledOnce;
+      scope.form[0].onChange.should.have.calledWith('Foo');
+      
+      scope.person.name = 'Bar';
+      $rootScope.$apply();
+      
+      scope.form[0].onChange.should.have.been.calledTwice;
+      scope.form[0].onChange.should.have.calledWith('Bar');
+    });
+  });
+
 });


### PR DESCRIPTION
Hello,

The basic idea comes from ON-OFF with a state-dependant style : 
I wanted the off to be red & the on to be green.

I managed to do that with onChange callback but 2 problems :
* this doesn't work for the initial state.
* this doesn't work on external model update.

[Check the Plunker](http://plnkr.co/edit/Hrh8WCxiCqdACeziLE2V?p=preview)

So here is a solution.
