### PR TITLE
Enhance array container check to manage arrays involving complex objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,53 @@
 node_modules
 coverage
 bower_components
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+

--- a/src/directives/array.js
+++ b/src/directives/array.js
@@ -154,6 +154,20 @@ angular.module('schemaForm').directive('sfArray', ['sfSelect', 'schemaForm', 'sf
           if (form.titleMap && form.titleMap.length > 0) {
             scope.titleMapValues = [];
 
+            // Check that an array contains an item
+            var isItemInArray = function(arr, item){
+                if(form.subKey){
+                    var found = false;
+                    arr.every(function(arrItem){
+                        found = (arrItem[form.subKey] || arrItem) === item.value;
+                        return !found;
+                    });
+                    return found;
+                } else{
+                    return arr.indexOf(item.value) !== -1;
+                }
+            };
+
             // We watch the model for changes and the titleMapValues to reflect
             // the modelArray
             var updateTitleMapValues = function(arr) {
@@ -161,7 +175,7 @@ angular.module('schemaForm').directive('sfArray', ['sfSelect', 'schemaForm', 'sf
               arr = arr || [];
 
               form.titleMap.forEach(function(item) {
-                scope.titleMapValues.push(arr.indexOf(item.value) !== -1);
+                scope.titleMapValues.push(isItemInArray(arr, item));
               });
 
             };


### PR DESCRIPTION
Hello,

I am using `angular-schema-form` in the following environment:
* Java backend
* [jackson-module-jsonSchema](https://github.com/FasterXML/jackson-module-jsonSchema) to generate my beans json schema
* Angular frontend

By default, with Jackson, our java enums are serialized to string.
But our enums are holding additional attributes (i.e. labelCode for the user understandable enum value description).
So we managed to serialize our enums into complex objects.

This caused an issue while generating combos for enums with `angular-schema-form`.
To resolve this, we copied and modified `angular-schema-form` default templates to map them with the `value` attribute ouf our enums.
Here is an extract of our `select.html` template (note the modification made to `ng-model`):
```html
<select ng-model="$$value$$.value"
              ng-model-options="form.ngModelOptions"
              ng-disabled="form.readonly"
              sf-changed="form"
              class="form-control {{form.fieldHtmlClass}}"
              schema-validate="form"
              name="{{form.key.slice(-1)[0]}}">
          <option ng-if="item.name" ng-repeat="item in form.titleMap" value="{{item.value}}">{{item.name | translate}}</option>
      </select>
```

This worked well for `select.html`.

But it doesn't work with `checkboxes.html`, because we receive in our model, we receive the following array structure:
```javascript
[{value: "ONE",
  labelCode: "common.one"},
  {value: "TWO",
  labelCode: "common.two"}]
```
Because the checked verification is performed with `array.indexOf(item.value)`, initial checkboxes values are wrong.

The purpose of this pull request is to allow users to specify a `subKey` attribute in case of array holding complex objects and handle container check on the value of the subKey attribute.