### PR TITLE
Add `interp()` view helper

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -76,6 +76,7 @@ available here for you to act on.
 | errorMessage(msg) | Error message formatting, makes validationMessage option work. |
 | evalInScope(expr, locals) | Eval supplied expression, ie scope.$eval |
 | evalExpr(expr, locals) | Eval an expression in the parent scope of the main `sf-schema` directive. |
+| interp(expr, locals) | Interpolate an expression which may or may not contain expression `{{ }}` sequences |
 | buttonClick($event, form)  | Use this with ng-click to execute form.onClick |
 
 ### The magic $$value$$

--- a/src/services/decorators.js
+++ b/src/services/decorators.js
@@ -30,8 +30,8 @@ angular.module('schemaForm').provider('schemaFormDecorators',
   };
 
   var createDirective = function(name) {
-    $compileProvider.directive(name, ['$parse', '$compile', '$http', '$templateCache',
-      function($parse,  $compile,  $http,  $templateCache) {
+    $compileProvider.directive(name, ['$parse', '$compile', '$http', '$templateCache', '$interpolate',
+      function($parse,  $compile,  $http,  $templateCache, $interpolate) {
 
         return {
           restrict: 'AE',
@@ -40,7 +40,7 @@ angular.module('schemaForm').provider('schemaFormDecorators',
           scope: true,
           require: '?^sfSchema',
           link: function(scope, element, attrs, sfSchema) {
-
+            
             //Keep error prone logic from the template
             scope.showTitle = function() {
               return scope.form && scope.form.notitle !== true && scope.form.title;
@@ -104,6 +104,23 @@ angular.module('schemaForm').provider('schemaFormDecorators',
               if (expression) {
                 return scope.$eval(expression, locals);
               }
+            };
+            
+            /**
+             * Interpolate the expression.
+             * Similar to `evalExpr()` and `evalInScope()`
+             * but will not fail if the expression is
+             * text that contains spaces.
+             * 
+             * Use the Angular `{{ interpolation }}`
+             * braces to access properties on `locals`.
+             * 
+             * @param  {string} content The string to interpolate.
+             * @param  {Object} locals (optional) Properties that may be accessed in the `expression` string.
+             * @return {Any} The result of the expression or `undefined`.
+             */
+            scope.interp = function(expression, locals){
+              return (expression && $interpolate(expression)(locals));
             };
 
             /**


### PR DESCRIPTION
Addresses Textalk/angular-schema-form#276

Adds a new `interp()` view helper that will interpolate strings, optionally containing Angular expressions.

This is almost the same as `evalExpr()` but doesn't assume the content is an expression.
Instead it parses expressions that use the standard Angular escape sequence: `{{ }}`

This demo shows how this can be used to address #276 (with a custom `tabarray` field):
https://github.com/Coridyn/angular-schema-form/tree/demo/tabarray-broken
(Select the "Tab Array (Fixed)" example)