### PR TITLE
Update tabarray template to use interpolation instead of eval

### DIFF
--- a/examples/data/tabarray.json
+++ b/examples/data/tabarray.json
@@ -43,7 +43,7 @@
 	  "style": {
 		"remove": "btn-danger"
 	  },
-      "title": "value.name || 'Tab '+$index",
+      "title": "{{ value.name || 'Tab '+$index }}",
       "items": [
         "comments[].name",
         "comments[].email",

--- a/src/directives/decorators/bootstrap/tabarray.html
+++ b/src/directives/decorators/bootstrap/tabarray.html
@@ -8,7 +8,7 @@
       <li ng-repeat="item in modelArray track by $index"
           ng-click="$event.preventDefault() || (selected.tab = $index)"
           ng-class="{active: selected.tab === $index}">
-          <a href="#">{{evalExpr(form.title,{'$index':$index, value: item}) || $index}}</a>
+          <a href="#">{{interp(form.title,{'$index':$index, value: item}) || $index}}</a>
       </li>
       <li ng-hide="form.readonly" ng-click="$event.preventDefault() || (selected.tab = appendToArray().length - 1)">
         <a href="#">
@@ -44,7 +44,7 @@
       <li ng-repeat="item in modelArray track by $index"
           ng-click="$event.preventDefault() || (selected.tab = $index)"
           ng-class="{active: selected.tab === $index}">
-          <a href="#">{{evalExpr(form.title,{'$index':$index, value: item}) || $index}}</a>
+          <a href="#">{{interp(form.title,{'$index':$index, value: item}) || $index}}</a>
       </li>
       <li ng-hide="form.readonly" ng-click="$event.preventDefault() || appendToArray()">
         <a href="#">


### PR DESCRIPTION
Addresses the other half of #276 by changing `tabarray.html` to use `interp()`.

Here's the rest of the commit message if it helps with writing up the change:

----


FORM CHANGES:

If you aren't using expressions in your form titles then
no changes are needed.

However, if your tabarray titles contain implicit Angular
expressions like this:

```json
    {
      "form": [
        {
          "type": "tabarray",
          "title": "value.name || 'Tab '+$index",
        }
      ]
    }
```

(previously "title" was interpolated)

Then you should change this to explicit expressions
by wrapping them with the Angular expression
delimiter "{{ }}":

```json
    {
      "form": [
        {
          "type": "tabarray",
          "title": "{{ value.name || 'Tab '+$index }}",
        }
      ]
    }
```

You can include multiple expressions or
mix expressions and text as needed:

```json
    {
      "form": [
        {
          "type": "tabarray",
          "title": "My {{ value.name }} is:",
        }
      ]
    }
```