### PR TITLE
Schema validation fix for Angular 1.2  ($setDirty)

### DIFF
--- a/src/directives/schema-validate.js
+++ b/src/directives/schema-validate.js
@@ -63,9 +63,12 @@ angular.module('schemaForm').directive('schemaValidate', ['sfValidator', 'sfSele
 
       // Listen to an event so we can validate the input on request
       scope.$on('schemaFormValidate', function() {
-        // FIXME: Try to make a fix for angular 1.2
-        if (ngModel.$setDirty()) {
+        if (ngModel.$setDirty) {
+          // Angular 1.3+
           ngModel.$setDirty();
+        } else {
+          // Angular 1.2
+          ngModel.$setViewValue(ngModel.$viewValue);
         }
         validate(ngModel.$viewValue);
       });


### PR DESCRIPTION
I am required to support IE8 and am therefore limited to Angular JS 1.2

I am sure you would make this fix in due course, but I have deadlines!  :-)

The Angular 1.2 version of $setDirty taken from http://makandracards.com/makandra/29625-setdirty-for-angular-1-2

I also fixed a typo - `if(ngModel.$setDirty())` should be `if(ngModel.$setDirty)`  (right?)