### PR TITLE
Added method to set schemaError explicitly, in this case its possible to...

### DIFF
--- a/src/directives/array.js
+++ b/src/directives/array.js
@@ -202,6 +202,9 @@ angular.module('schemaForm').directive('sfArray', ['sfSelect', 'schemaForm', 'sf
           // If there is a ngModel present we need to validate when asked.
           if (ngModel) {
             var error;
+            function setSchemaError(value) {
+              error = value;
+            }
 
             scope.validateArray = function() {
               // The actual content of the array is validated by each field
@@ -230,7 +233,7 @@ angular.module('schemaForm').directive('sfArray', ['sfSelect', 'schemaForm', 'sf
                 // Set viewValue to trigger $dirty on field. If someone knows a
                 // a better way to do it please tell.
                 ngModel.$setViewValue(scope.modelArray);
-                error = result.error;
+                setSchemaError(result.error);
                 ngModel.$setValidity('tv4-' + result.error.code, false);
               }
             };
@@ -244,6 +247,8 @@ angular.module('schemaForm').directive('sfArray', ['sfSelect', 'schemaForm', 'sf
             scope.hasError = function() {
               return ngModel.$invalid;
             };
+
+            scope.setSchemaError = setSchemaError;
 
             scope.schemaError = function() {
               return error;

--- a/src/directives/schema-validate.js
+++ b/src/directives/schema-validate.js
@@ -15,6 +15,9 @@ angular.module('schemaForm').directive('schemaValidate', ['sfValidator', 'sfSele
       scope.$emit('schemaFormPropagateNgModelController', ngModel);
 
       var error = null;
+      function setSchemaError(value) {
+        error = value;
+      }
 
       var getForm = function() {
         if (!form) {
@@ -51,7 +54,7 @@ angular.module('schemaForm').directive('schemaValidate', ['sfValidator', 'sfSele
         if (!result.valid) {
           // it is invalid, return undefined (no model update)
           ngModel.$setValidity('tv4-' + result.error.code, false);
-          error = result.error;
+          setSchemaError(result.error);
           return undefined;
         }
         return viewValue;
@@ -69,6 +72,8 @@ angular.module('schemaForm').directive('schemaValidate', ['sfValidator', 'sfSele
         }
         validate(ngModel.$viewValue);
       });
+
+      scope.setSchemaError = setSchemaError;
 
       scope.schemaError = function() {
         return error;


### PR DESCRIPTION
Hi!
Added method to set schemaError explicitly, in this case its possible to do external schema validation and display proper notifications.
So, my problem is, I do additional validation using tv4 and my schema to enable complex validation cases with anyOf/oneOf/allOf. But I cannot set error to display proper validation message because error object is in closure. I've tried this in my project with making "error" property to be accessible via scope.error(and I've removed schemaError() method) but this seems not proper solution, so I've created scope.setSchemaError() method to setup my own error object.