### PR TITLE
Support ['null', other_type] type. Fix #146

### DIFF
--- a/src/services/schema-form.js
+++ b/src/services/schema-form.js
@@ -5,6 +5,15 @@
  */
 angular.module('schemaForm').provider('schemaForm',
 ['sfPathProvider', function(sfPathProvider) {
+  var stripNullType = function(type) {
+    if (Array.isArray(type) && type.length == 2) {
+      if (type[0] === 'null')
+        return type[1];
+      if (type[1] === 'null')
+        return type[0];
+    }
+    return type;
+  }
 
   //Creates an default titleMap list from an enum, i.e. a list of strings.
   var enumToTitleMap = function(enm) {
@@ -35,7 +44,7 @@ angular.module('schemaForm').provider('schemaForm',
   };
 
   var defaultFormDefinition = function(name, schema, options) {
-    var rules = defaults[schema.type];
+    var rules = defaults[stripNullType(schema.type)];
     if (rules) {
       var def;
       for (var i = 0; i < rules.length; i++) {
@@ -88,7 +97,7 @@ angular.module('schemaForm').provider('schemaForm',
   };
 
   var text = function(name, schema, options) {
-    if (schema.type === 'string' && !schema['enum']) {
+    if (stripNullType(schema.type) === 'string' && !schema['enum']) {
       var f = stdFormObj(name, schema, options);
       f.key  = options.path;
       f.type = 'text';
@@ -100,7 +109,7 @@ angular.module('schemaForm').provider('schemaForm',
   //default in json form for number and integer is a text field
   //input type="number" would be more suitable don't ya think?
   var number = function(name, schema, options) {
-    if (schema.type === 'number') {
+    if (stripNullType(schema.type) === 'number') {
       var f = stdFormObj(name, schema, options);
       f.key  = options.path;
       f.type = 'number';
@@ -110,7 +119,7 @@ angular.module('schemaForm').provider('schemaForm',
   };
 
   var integer = function(name, schema, options) {
-    if (schema.type === 'integer') {
+    if (stripNullType(schema.type) === 'integer') {
       var f = stdFormObj(name, schema, options);
       f.key  = options.path;
       f.type = 'number';
@@ -120,7 +129,7 @@ angular.module('schemaForm').provider('schemaForm',
   };
 
   var checkbox = function(name, schema, options) {
-    if (schema.type === 'boolean') {
+    if (stripNullType(schema.type) === 'boolean') {
       var f = stdFormObj(name, schema, options);
       f.key  = options.path;
       f.type = 'checkbox';
@@ -130,7 +139,7 @@ angular.module('schemaForm').provider('schemaForm',
   };
 
   var select = function(name, schema, options) {
-    if (schema.type === 'string' && schema['enum']) {
+    if (stripNullType(schema.type) === 'string' && schema['enum']) {
       var f = stdFormObj(name, schema, options);
       f.key  = options.path;
       f.type = 'select';
@@ -143,7 +152,7 @@ angular.module('schemaForm').provider('schemaForm',
   };
 
   var checkboxes = function(name, schema, options) {
-    if (schema.type === 'array' && schema.items && schema.items['enum']) {
+    if (stripNullType(schema.type) === 'array' && schema.items && schema.items['enum']) {
       var f = stdFormObj(name, schema, options);
       f.key  = options.path;
       f.type = 'checkboxes';
@@ -156,7 +165,7 @@ angular.module('schemaForm').provider('schemaForm',
   };
 
   var fieldset = function(name, schema, options) {
-    if (schema.type === 'object') {
+    if (stripNullType(schema.type) === 'object') {
       var f   = stdFormObj(name, schema, options);
       f.type  = 'fieldset';
       f.items = [];
@@ -188,7 +197,7 @@ angular.module('schemaForm').provider('schemaForm',
 
   var array = function(name, schema, options) {
 
-    if (schema.type === 'array') {
+    if (stripNullType(schema.type) === 'array') {
       var f   = stdFormObj(name, schema, options);
       f.type  = 'array';
       f.key   = options.path;
@@ -386,7 +395,7 @@ angular.module('schemaForm').provider('schemaForm',
       ignore = ignore || {};
       globalOptions = globalOptions || {};
 
-      if (schema.type === 'object') {
+      if (stripNullType(schema.type) === 'object') {
         angular.forEach(schema.properties, function(v, k) {
           if (ignore[k] !== true) {
             var required = schema.required && schema.required.indexOf(k) !== -1;


### PR DESCRIPTION
This PR make the form can be generated as the simple type without the 'null' type. e.g. schema type ['null', 'string'] or ['string', 'null'] will do exactly as schema type 'string'.