### PR TITLE
Enhance the select field with null value support

### DIFF
--- a/src/directives/decorators/bootstrap/select.html
+++ b/src/directives/decorators/bootstrap/select.html
@@ -1,4 +1,4 @@
-<div class="form-group {{form.htmlClass}} schema-form-select"
+<div ng-if="form.allowAutoNullOption !== undefined" class="form-group {{form.htmlClass}} schema-form-select"
      ng-class="{'has-error': hasError(), 'has-success': hasSuccess(), 'has-feedback': form.feedback !== false}">
   <label class="control-label" ng-show="showTitle()">
     {{form.title}}
@@ -11,6 +11,25 @@
           schema-validate="form"
           ng-options="item.value as item.name group by item.group for item in form.titleMap"
           name="{{form.key.slice(-1)[0]}}">
+    <option ng-if="form.allowAutoNullOption !== false" value="">{{form.allowAutoNullOption !== true ? form.allowAutoNullOption : ''}}</option>
   </select>
   <div class="help-block" sf-message="form.description"></div>
+</div>
+<div ng-if="form.allowAutoNullOption === undefined" class="form-group {{form.htmlClass}} schema-form-select"
+     ng-class="{'has-error': hasError(), 'has-success': hasSuccess(), 'has-feedback': form.feedback !== false}">
+  <label class="control-label" ng-show="showTitle()">
+    {{form.title}}
+  </label>
+  <select ng-model="$$value$$"
+          ng-model-options="form.ngModelOptions"
+          ng-disabled="form.readonly"
+          sf-changed="form"
+          class="form-control {{form.fieldHtmlClass}}"
+          schema-validate="form"
+          ng-options="item.value as item.name for item in form.titleMap"
+          name="{{form.key.slice(-1)[0]}}">
+  </select>
+  <div class="help-block"
+       ng-show="(hasError() && errorMessage(schemaError())) || form.description"
+       ng-bind-html="(hasError() && errorMessage(schemaError())) || form.description"></div>
 </div>

--- a/src/services/schema-form.js
+++ b/src/services/schema-form.js
@@ -359,6 +359,21 @@ angular.module('schemaForm').provider('schemaForm',
           }
         }
 
+        if (obj.type === 'select' && obj.titleMap && obj.allowAutoNullOption !== false) {
+          // when allowNull === false, we leave titleMap as it is.
+          // else we filter out the null value and setup allowNull to the label
+          // so the select template will behaviour different according to it.
+          obj.titleMap = obj.titleMap.filter(function(item) {
+            if (item.value === null) {
+              // so we have null value option, setup the label and make it always selectable.
+              if (obj.allowAutoNullOption === undefined)
+                obj.allowAutoNullOption = item.name === null ? '' : item.name;
+              return false;
+            }
+            return true;
+          });
+        }
+
         // Are we inheriting readonly?
         if (readonly === true) { // Inheriting false is not cool.
           obj.readonly = true;


### PR DESCRIPTION
Angular's select with ngOptions has 3 type about the null value (the value="" options). reference: https://docs.angularjs.org/api/ng/directive/ngOptions

1. current angular-schema-form default implement, which will add a empty value options which result null by default if the model value does not match any enum/titleMap value and be selected by default. but once user selected any non-empty value, that empty value option is gone, which make the user have to make a choice but without a default selection if the field is also required.

2. if put an <option value=""> tag in the select tag, the empty option will be there like the previous type, except that the empty option won't get disappeared after user selected other option, so it make the null value always an option.

3. if put an invisible <option value="">, even with ng-if="false", it will never populate an empty option, the select will have the first option selected if the model value does not match any option value.

So, above 3 type of use cases are all useful, but current angular-schema-form implement only give use the first use case support. This PR will add the later 2 type of select/ng-options support, so we can do with the null value better in many use cases.

e.g. 

- for a select field, the null value is a valid option, and we want it always selectable, then we should make the schema type be ['null', 'string'], and use any following methods:
   1. schema use enum, without titleMap. Then should put null as one of the possible value in the enum (if use enum schema, because tv4 will validate the value to the enum value list, so if use enum, null should be in the enum), this will make the null value always selectable. if want non-blank label for null value option, set form's allowAutoNullOption property for the select field to the label text you want.
   2. schema use enum, with titleMap. Same as above, except the code will auto detect the titleMap (array type titleMap only) with the null value, if found, will auto use the name found as the null value option label (code internally auto setup allowAutoNullOption to the label), while you can still override it by set allowAutoNullOption to value you want.
   3. schema not use enum, with titleMap (array type titleMap only). same as above, code will detect the null value label and auto setup allowAutoNullOption to the label text.

- some times, you do not want a default empty option, you want the first option be selected by default, it can also be done by this PR, just set the form property allowAutoNullOption of the select field to false will do that.

- There are also some rare cased, you want null value but not be the first option, for such use case, this PR can still do that, by set allowAutoNullOption to false, and include the null value in enum or your titleMap at the prefered position will simply do it.