### PR TITLE
add optional icon to action buttons

### DIFF
--- a/src/directives/decorators/bootstrap/actions.html
+++ b/src/directives/decorators/bootstrap/actions.html
@@ -9,5 +9,5 @@
           type="button"
           ng-disabled="form.readonly"
           ng-if="item.type !== 'submit'"
-          ng-click="buttonClick($event,item)">{{item.title}}</button>
+          ng-click="buttonClick($event,item)"><span ng-if="item.icon" class="{{item.icon}}"></span>{{item.title}}</button>
 </div>


### PR DESCRIPTION
Adds an optional icon to action buttons. Example:

```js
{
    type: 'button',
    title: 'Save',
    style: 'btn-primary',
    icon: 'glyphicon glyphicon-ok',
    onClick: 'save()'
}
```

![angular-schema-form-button-icon](https://cloud.githubusercontent.com/assets/27403/6726470/fa733fc2-ce17-11e4-84d9-a49c8dfb8a5f.png)
