### PR TITLE
Add global form option to disable tv4 validation

### DIFF
--- a/src/directives/schema-validate.js
+++ b/src/directives/schema-validate.js
@@ -41,6 +41,11 @@ angular.module('schemaForm').directive('schemaValidate', ['sfValidator', 'sfSele
           return viewValue;
         }
 
+        // Omit TV4 validation
+        if (scope.options && scope.options.tv4Validation === false) {
+          return viewValue;
+        }
+
         var result =  sfValidator.validate(form, viewValue);
         // Since we might have different tv4 errors we must clear all
         // errors that start with tv4-


### PR DESCRIPTION
Useful in cases where you want to set validation messages only manually (e.g. from an API response) and use `angular-schema-form` primarily to render forms. When this config option is set on in `sf-options` it will completely omit tv4 validation for the form. Example:

```
<form sf-schema="schema" sf-form="form" sf-model="model" sf-options="sf-options="{ tv4Validation: false }"></form>
```