### PR TITLE
fix(fieldset): make fieldsets properly respect notitle

### DIFF
--- a/src/directives/decorators/bootstrap/fieldset-trcl.html
+++ b/src/directives/decorators/bootstrap/fieldset-trcl.html
@@ -1,5 +1,5 @@
 <fieldset ng-disabled="form.readonly" class="schema-form-fieldset {{form.htmlClass}}">
-  <legend ng-show="form.title">{{ form.title }}</legend>
+  <legend ng-class="{'sr-only': !showTitle() }">{{ form.title }}</legend>
   <div class="help-block" ng-show="form.description" ng-bind-html="form.description"></div>
   <div ng-transclude></div>
 </fieldset>

--- a/src/directives/decorators/bootstrap/fieldset.html
+++ b/src/directives/decorators/bootstrap/fieldset.html
@@ -1,5 +1,5 @@
 <fieldset ng-disabled="form.readonly" class="schema-form-fieldset {{form.htmlClass}}">
-  <legend ng-show="form.title">{{ form.title }}</legend>
+  <legend ng-class="{'sr-only': !showTitle() }">{{ form.title }}</legend>
   <div class="help-block" ng-show="form.description" ng-bind-html="form.description"></div>
   <sf-decorator ng-repeat="item in form.items" form="item"></sf-decorator>
 </fieldset>


### PR DESCRIPTION
This fix should visibly hide the title on fieldsets while allowing screen readers to read them if they exist.

NOTE: I can change this to a simple `ng-show="showTitle()"` instead if that would be better.

Addresses #203 