### PR TITLE
Update list variable when watching for array changes

### DIFF
--- a/src/directives/array.js
+++ b/src/directives/array.js
@@ -43,7 +43,7 @@ angular.module('schemaForm').directive('sfArray', ['sfSelect', 'schemaForm', 'sf
           // the outside so let's watch for that. We use an ordinary watch since the only case
           // we're really interested in is if its a new instance.
           scope.$watch('model' + sfPath.normalize(form.key), function(value) {
-            scope.modelArray = value;
+            list = scope.modelArray = value;
           });
 
           // Since ng-model happily creates objects in a deep path when setting a


### PR DESCRIPTION
In 5c6630b1899af38f1a302454ef87e40b600a0888, watching of arrays was refactored to remove a call to `sfSelect`, however in the process the `list` variable stopped getting updated. This led to adverse behaviour when adding new array items in the editor due to `list` and `scope.modelArray` being out of sync. This PR ensures the `list` variable is kept in sync with `scope.modelArray` when the array changes.