### PR TITLE
Fix custom validations on 1.2

### DIFF
--- a/dist/schema-form.js
+++ b/dist/schema-form.js
@@ -512,12 +512,11 @@ angular.module('schemaForm').provider('schemaFormDecorators',
                       }
 
                       if (scope.ngModel && error) {
-                        if (scope.ngModel.$setDirty()) {
-                          scope.ngModel.$setDirty();
-                        } else {
-                          // FIXME: Check that this actually works on 1.2
+                        if (angular.version.major === 1 && angular.version.minor <= 2) {
                           scope.ngModel.$dirty = true;
                           scope.ngModel.$pristine = false;
+                        } else if (scope.ngModel.$setDirty()) {
+                          scope.ngModel.$setDirty();
                         }
 
                         // Set the new validation message if one is supplied


### PR DESCRIPTION
This was breaking in Angular 1.2 because the browser dies on $setDirty as this method can not be called as it doesn't exist.

The fix is to check if the version is <= 1.2 and perform the .$dirty / .$pristine on the model.