### PR TITLE
Fixing schema.{min,max}Items message mixup.

### DIFF
--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -31,8 +31,8 @@ angular.module('schemaForm').provider('sfErrorMessage', function() {
     303: 'Additional properties not allowed',
     304: 'Dependency failed - key must exist',
     // Array errors
-    400: 'Array is too short ({{value.length}}), minimum {{schema.maxItems}}',
-    401: 'Array is too long ({{value.length}}), maximum {{schema.minItems}}',
+    400: 'Array is too short ({{value.length}}), minimum {{schema.minItems}}',
+    401: 'Array is too long ({{value.length}}), maximum {{schema.maxItems}}',
     402: 'Array items are not unique',
     403: 'Additional items not allowed',
     // Format errors


### PR DESCRIPTION
Currently maxItems is shown for to short arrays and minItems for to long arrays.
It should be exactly the other way around:

![screen shot 2015-06-15 at 18 24 59](https://cloud.githubusercontent.com/assets/2906107/8164799/e3a3c398-138b-11e5-86e1-9a35b9146070.png)
