### PR TITLE
Revalid before apply tv4 validation, fix #440

### DIFF
--- a/src/services/decorators.js
+++ b/src/services/decorators.js
@@ -247,7 +247,10 @@ angular.module('schemaForm').provider('schemaFormDecorators',
 
                         scope.ngModel.$setValidity(error, validity === true);
 
-                        if (validity === true) {
+                        if (validity === true && !scope.ngModel.$valid) {
+                          // Previous the model maybe invalid, then the model value is undefined.
+                          // To make the validation to the tv4 works, we need also re-trigger validators
+                          scope.ngModel.$validate();
                           // Setting or removing a validity can change the field to believe its valid
                           // but its not. So lets trigger its validation as well.
                           scope.$broadcast('schemaFormValidate');


### PR DESCRIPTION
before we re-valid the field value, we need call $validate() to re-push the viewValue to the validators, else we will always use the undefined modelValue if previous validation is failed due to any of the validators but currently it can pass it.