### PR TITLE
Fix build on case sensitive systems

### DIFF
--- a/gulp/tasks/minify.js
+++ b/gulp/tasks/minify.js
@@ -16,7 +16,7 @@ gulp.task('minify', function() {
     dependencies: function() {
       return [
         {name: 'angular'},
-        {name: 'ObjectPath'},
+        {name: 'objectpath'},
         {name: 'tv4'},
       ]
     },

--- a/src/sfPath.js
+++ b/src/sfPath.js
@@ -1,6 +1,6 @@
 angular.module('schemaForm').provider('sfPath',
 [function() {
-  var sfPath = {parse: ObjectPath.parse};
+  var sfPath = {parse: objectpath.parse};
 
   // if we're on Angular 1.2.x, we need to continue using dot notation
   if (angular.version.major === 1 && angular.version.minor < 3) {
@@ -8,7 +8,7 @@ angular.module('schemaForm').provider('sfPath',
       return Array.isArray(arr) ? arr.join('.') : arr.toString();
     };
   } else {
-    sfPath.stringify = ObjectPath.stringify;
+    sfPath.stringify = objectpath.stringify;
   }
 
   // We want this to use whichever stringify method is defined above,


### PR DESCRIPTION
In browserify context, when requiring `angular-schema-form` in a case sensitive system (my case ubuntu):
```
Browserify Error: Cannot find module 'ObjectPath' from '/home/gitlab-runner/tmp/builds/project-51/backend/node_modules/angular-schema-form/dist'
```

Obviously all dependencies name are always in lower case. (bower and npm) 