### PR TITLE
Fixing enum error Message

### DIFF
--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -8,7 +8,7 @@ angular.module('schemaForm').provider('sfErrorMessage', function() {
   var defaultMessages = {
     'default': 'Field does not validate',
     0: 'Invalid type, expected {{schema.type}}',
-    1: 'No enum match for: {{value}}',
+    1: 'No enum match for: {{viewValue}}',
     10: 'Data does not match any schemas from "anyOf"',
     11: 'Data does not match any schemas from "oneOf"',
     12: 'Data is valid against more than one schema from "oneOf"',


### PR DESCRIPTION
If there is an error, the enum Property will actually not be set, so we need to use `{{viewValue}}` instead of `{{value}}`:

![screen shot 2015-06-29 at 15 30 57](https://cloud.githubusercontent.com/assets/2906107/8408890/faa48af8-1e73-11e5-84ac-360df9aafb41.png)
