### PR TITLE
Add npm/jspm-compliant index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+/* */ 
+
+require("./dist/schema-form.min");
+require("./dist/bootstrap-decorator");

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.4",
   "description": "Create complex forms from a JSON schema with angular.",
   "repository": "Textalk/angular-schema-form",
-  "main": "dist/schema-form.min.js",
+  "main": "index.js",
   "filename": "dist/schema-form.min.js",
   "homepage": "http://schemaform.io",
   "scripts": {


### PR DESCRIPTION
This commit adds module loader support for SystemJS/JSPM by defining entry points via require statements in an index.js-file.
The "filename" attribute in package.json seems like a non-standard package.json-attribute, anyone knows why?