### PR TITLE
Formselect: fix required and path

### DIFF
--- a/src/directives/formselect.js
+++ b/src/directives/formselect.js
@@ -12,43 +12,37 @@ angular.module('schemaForm').directive('sfFormSelect', ['sfSelect', 'schemaForm'
         // Keeps the model data for each form
         var formData = [];
         // TODO: Watch the model value and pick a form to match it
-        var once = scope.$parent.$watch(attrs.sfFormSelect, function(form) {
-          if (!form) {
-            return;
+        var form = scope[attrs.sfFormSelect];
+        var model = sfSelect(form.key, scope.model);
+
+        // Watch the model value and change to a form that matches it
+        var key = sfPath.normalize(form.key);
+        scope.$parent.$watch('model' + key, function(value) {
+          model = scope.modelData = value;
+          // If the selected form still validates, make sure we don't change it
+          if (angular.isNumber(scope.selectedForm.value)) {
+            var r = sfValidator.validate(form.items[scope.selectedForm.value], model);
+            if (r.valid) {
+              return;
+            }
           }
-          once();
-
-          var model = sfSelect(form.key, scope.model);
-
-          // Watch the model value and change to a form that matches it
-          var key = sfPath.normalize(form.key);
-          scope.$parent.$watch('model' + key, function(value) {
-            model = scope.modelData = value;
-            // If the selected form still validates, make sure we don't change it
-            if (angular.isNumber(scope.selectedForm.value)) {
-              var r = sfValidator.validate(form.items[scope.selectedForm.value], model);
-              if (r.valid) {
-                return;
-              }
+          //Search for a form that is valid for the given model data
+          for (var i = 0; i < form.items.length; i++) {
+            var result = sfValidator.validate(form.items[i], model);
+            if (result.valid) {
+              scope.selectedForm.value = i;
+              break;
             }
-            //Search for a form that is valid for the given model data
-            for (var i = 0; i < form.items.length; i++) {
-              var result = sfValidator.validate(form.items[i], model);
-              if (result.valid) {
-                scope.selectedForm.value = i;
-                break;
-              }
-            }
-          });
+          }
+        });
 
-          // Restore data associated with selected form
-          scope.$watch('selectedForm.value', function(selected, oldForm) {
-            formData[oldForm] = model;
-            if (formData[selected]) {
-              sfSelect(form.key, scope.model, formData[selected]);
-            }
-            // TODO: Fill defaults if we don't have data for this form
-          });
+        // Restore data associated with selected form
+        scope.$watch('selectedForm.value', function(selected, oldForm) {
+          formData[oldForm] = model;
+          if (formData[selected]) {
+            sfSelect(form.key, scope.model, formData[selected]);
+          }
+          // TODO: Fill defaults if we don't have data for this form
         });
       }
     };

--- a/src/services/builder.js
+++ b/src/services/builder.js
@@ -95,7 +95,7 @@ angular.module('schemaForm').provider('sfBuilder', ['sfPathProvider', function(s
           var sub = args.form[n.getAttribute('sf-field-transclude')];
           if (sub) {
             sub = Array.isArray(sub) ? sub : [sub];
-            var childFrag = args.build(sub, args.path + '.' + sub, args.state);
+            var childFrag = args.build(sub, args.path + '.' + n.getAttribute('sf-field-transclude'), args.state);
             n.appendChild(childFrag);
           }
         }

--- a/src/services/schema-form.js
+++ b/src/services/schema-form.js
@@ -325,13 +325,9 @@ angular.module('schemaForm').provider('schemaForm',
         value: index
       });
 
-      var required = schema.required &&
-                     schema.required.indexOf(options.path[options.path.length - 1]) !== -1;
-
-
       var subForm = defaultFormDefinition(name, s, {
         path: subPath,
-        required: required || false, //TODO: validate that this is what we want.
+        required: options.required || false,
         lookup: options.lookup,
         ignore: options.ignore,
         global: options.global

--- a/src/services/schema-form.js
+++ b/src/services/schema-form.js
@@ -521,6 +521,10 @@ angular.module('schemaForm').provider('schemaForm',
           asyncTemplates.push(obj);
         }
 
+        // After merge, we don't want the formselect indexes in the keys anymore
+        if (obj.key) {
+          obj.key = obj.key.filter(function(keypart) {return keypart.indexOf('{') != 0;});
+        }
         return obj;
       }));
     };

--- a/src/services/schema-form.js
+++ b/src/services/schema-form.js
@@ -455,6 +455,10 @@ angular.module('schemaForm').provider('schemaForm',
           obj = {key: obj};
         }
 
+        if (Array.isArray(obj)) {
+          obj = {type: 'fieldset', items: obj};
+        }
+
         if (obj.key) {
           if (typeof obj.key === 'string') {
             obj.key = sfPathProvider.parse(obj.key);


### PR DESCRIPTION
The path was getting set in the builder as the string transcription of the items array (`[Object, Object]`) or something like that.

Required property would only be set by a parent object, right? So it just makes sense to pass on the one from ourselves to the subforms.